### PR TITLE
added isEqual

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,10 @@
 {
   "root": true,
-  "plugins": ["prettier", "jest"],
+  "plugins": ["prettier"],
   "extends": ["eslint:recommended", "prettier"],
   "env": {
     "browser": true,
     "es6": true,
-    "jest/globals": true,
     "node": true
   },
   "globals": {},

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _@creuna/utils/deep-clone_
 * `object`: object
 * returns: object
 
-Returns a deep clone of an object (any nested objects or arrays will also be cloned)
+Returns a deep clone of an object (any nested objects or arrays will also be cloned). Be aware that this uses JSON.stringify, meaning that any array elements or object values that are `undefined` will be stripped
 
 ### fromQueryString(_queryString_)
 
@@ -91,6 +91,16 @@ _@creuna/utils/is-element-in-viewport_
 * returns: boolean
 
 Checks whether the given element is fully visible in the viewport
+
+### isEqual(_thing1, thing2_)
+
+_@creuna/utils/is-equal_
+
+* `thing1`: any
+* `thing1`: any
+* returns: boolean
+
+Checks whether two things are equal (deep comparison for objects and arrays). This uses JSON.stringify, so be aware that array elements or object values that are `undefined` will be stripped.
 
 ### kebabToCamel(_kebabString_)
 

--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ _@creuna/utils/is-element-in-viewport_
 
 Checks whether the given element is fully visible in the viewport
 
-### isEqual(_thing1, thing2_)
+### isEqual(_a, b_)
 
 _@creuna/utils/is-equal_
 
-* `thing1`: any
-* `thing1`: any
+* `a`: any
+* `b`: any
 * returns: boolean
 
-Checks whether two things are equal (deep comparison for objects and arrays). This uses JSON.stringify, so be aware that array elements or object values that are `undefined` will be stripped.
+Checks whether `a` and `b` are equal (deep comparison for objects and arrays). This uses `JSON.stringify`, so be aware that array elements or object values that are `undefined` will be stripped.
 
 ### kebabToCamel(_kebabString_)
 

--- a/__tests__/is-equal.test.js
+++ b/__tests__/is-equal.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 
 import isEqual from '../is-equal';
 
-test('is-equal: object', t => {
+test('object', t => {
   const o1 = { a: 1, b: 2, c: { d: 4 } };
   const o2 = { a: 1, b: 2, c: { d: 4 } };
 
@@ -10,7 +10,7 @@ test('is-equal: object', t => {
   t.is(isEqual(o1, o2), true);
 });
 
-test('is-equal: array', t => {
+test('array', t => {
   const a1 = [1, 2, [3, 4]];
   const a2 = [1, 2, [3, 4]];
 
@@ -18,7 +18,7 @@ test('is-equal: array', t => {
   t.is(isEqual(a1, a2), true);
 });
 
-test('is-equal: number', t => {
+test('number', t => {
   t.plan(1);
   t.is(isEqual(1, 1), true);
 });

--- a/__tests__/is-equal.test.js
+++ b/__tests__/is-equal.test.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+
+import isEqual from '../is-equal';
+
+test('is-equal: object', t => {
+  const o1 = { a: 1, b: 2, c: { d: 4 } };
+  const o2 = { a: 1, b: 2, c: { d: 4 } };
+
+  t.plan(1);
+  t.is(isEqual(o1, o2), true);
+});
+
+test('is-equal: array', t => {
+  const a1 = [1, 2, [3, 4]];
+  const a2 = [1, 2, [3, 4]];
+
+  t.plan(1);
+  t.is(isEqual(a1, a2), true);
+});
+
+test('is-equal: number', t => {
+  t.plan(1);
+  t.is(isEqual(1, 1), true);
+});

--- a/__tests__/is-equal.test.js
+++ b/__tests__/is-equal.test.js
@@ -2,20 +2,49 @@ import test from 'ava';
 
 import isEqual from '../is-equal';
 
-test('object', t => {
-  const o1 = { a: 1, b: 2, c: { d: 4 } };
-  const o2 = { a: 1, b: 2, c: { d: 4 } };
+test('boolean', t => {
+  t.plan(4);
 
-  t.is(isEqual(o1, o2), true);
+  t.is(isEqual(true, true), true);
+  t.is(isEqual(true, false), false);
+  t.is(isEqual(false, false), true);
+  t.is(isEqual(false, true), false);
+});
+
+test('object', t => {
+  const a = { a: 1, b: 2, c: { d: 4 } };
+  const b = { a: 1, b: 2, c: { d: 4 } };
+  const c = { a: 2, b: 3, c: { d: 5 } };
+
+  t.plan(2);
+  t.is(isEqual(a, b), true);
+  t.is(isEqual(a, c), false);
 });
 
 test('array', t => {
-  const a1 = [1, 2, [3, 4]];
-  const a2 = [1, 2, [3, 4]];
+  const a = [1, 2, [3, 4]];
+  const b = [1, 2, [3, 4]];
+  const c = [2, 3, [4, 5]];
 
-  t.is(isEqual(a1, a2), true);
+  t.plan(2);
+  t.is(isEqual(a, b), true);
+  t.is(isEqual(a, c), false);
 });
 
 test('number', t => {
+  t.plan(2);
   t.is(isEqual(1, 1), true);
+  t.is(isEqual(1, 2), false);
+});
+
+test('string', t => {
+  t.plan(2);
+  t.is(isEqual('foo', 'foo'), true);
+  t.is(isEqual('bar', 'baz'), false);
+});
+
+test('emoji', t => {
+  t.plan(2);
+  t.is(isEqual('👌🏻', '👌🏻'), true);
+  t.is(isEqual('👌🏻', '👏🏻'), false);
 });

--- a/__tests__/is-equal.test.js
+++ b/__tests__/is-equal.test.js
@@ -6,7 +6,6 @@ test('object', t => {
   const o1 = { a: 1, b: 2, c: { d: 4 } };
   const o2 = { a: 1, b: 2, c: { d: 4 } };
 
-  t.plan(1);
   t.is(isEqual(o1, o2), true);
 });
 
@@ -14,11 +13,9 @@ test('array', t => {
   const a1 = [1, 2, [3, 4]];
   const a2 = [1, 2, [3, 4]];
 
-  t.plan(1);
   t.is(isEqual(a1, a2), true);
 });
 
 test('number', t => {
-  t.plan(1);
   t.is(isEqual(1, 1), true);
 });

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import deepClone from './deep-clone';
 import fromQueryString from './from-query-string';
 import getData from './get-data';
 import isElementInViewport from './is-element-in-viewport';
+import isEqual from './is-equal';
 import isRunningOnClient from './is-running-on-client';
 import kebabToCamel from './kebab-to-camel';
 import kebabToPascal from './kebab-to-pascal';
@@ -24,6 +25,7 @@ export default {
   fromQueryString,
   getData,
   isElementInViewport,
+  isEqual,
   isRunningOnClient,
   kebabToCamel,
   kebabToPascal,

--- a/is-equal.js
+++ b/is-equal.js
@@ -1,0 +1,3 @@
+export default function(object, otherObject) {
+  return JSON.stringify(object) === JSON.stringify(otherObject);
+}

--- a/is-equal.js
+++ b/is-equal.js
@@ -1,3 +1,1 @@
-export default function(object, otherObject) {
-  return JSON.stringify(object) === JSON.stringify(otherObject);
-}
+export default (a, b) => JSON.stringify(a) === JSON.stringify(b);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/utils",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Creuna js utils",
   "main": "index.js",
   "files": ["*.js", "README.md", "LICENSE"],


### PR DESCRIPTION
When using `deepClone`, any object properties or array elements that are `undefined` will be stripped by `JSON.stringify`. Because of this, other implementations of deep comparison (like lodash isEqual) will in some cases fail on objects cloned with `deepClone`, so we need a comparison implemetation that also uses `JSON.stringify`.